### PR TITLE
Disabled bibliography 

### DIFF
--- a/Report/main.tex
+++ b/Report/main.tex
@@ -102,7 +102,7 @@
 
 
 % BIBLIOGRAFIA
-\printbibliography
-\addcontentsline{toc}{chapter}{\refname}
+% \printbibliography
+% \addcontentsline{toc}{chapter}{\refname}
 
 \end{document}


### PR DESCRIPTION
Until now the bibliography appeared in the ToC but not in the document since it is empty.

We should accept this before generating the final report if we end up not having a bibliography at all